### PR TITLE
Don't use maven artifact, we use local one

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -2,7 +2,15 @@ buildscript {
     repositories {
         google()
         jcenter()
-        maven { url "https://plugins.gradle.org/m2/" }
+        /*
+         As a standalone Android example you would need this maven repository,
+         but this example is more a development showcase, then a showcase how to use it
+         It uses the plugin from this local repository, by
+         includeBuild '../..'
+         from file settings.gradle
+         To make it clear, from where it comes from, it's commented out
+         */
+        // maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.2'


### PR DESCRIPTION
This example is now more a development showcase, then a showcase how to use it
 
It uses the plugin from this local repository, by
`includeBuild '../..'` from file `settings.gradle`
To make it clear, from where it comes from, `maven { url "https://plugins.gradle.org/m2/" }` is commented out