### PR TITLE
Pre release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,17 @@ jobs:
           skip-unshallow: 'true'
           commit-ish: HEAD
       - run: |
+          PRE_RELEASE=""
+          string='My long string'
+          if [[ ${{steps.tagger.outputs.tag}} == *"beta"* ]]; then
+            PRE_RELEASE="-p"
+          fi
+          if [[ ${{steps.tagger.outputs.tag}} == *"alpha"* ]]; then
+            PRE_RELEASE="-p"
+          fi
           assets=$(find . -name "*${{steps.tagger.outputs.tag}}*.jar" -or -name " *release.aar" | while read -r asset ; do echo "-a $asset" ; done)
-          hub release create ${assets} -m "${{steps.tagger.outputs.tag}}" "${{steps.tagger.outputs.tag}}"
+          set -x
+          hub release create $PRE_RELEASE ${assets} -m "${{steps.tagger.outputs.tag}}" "${{steps.tagger.outputs.tag}}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{steps.tagger.outputs.tag}}


### PR DESCRIPTION
Simply create a release with a tag and when `alpha` or `beta` is included, a pre-release will be created.
Please see my tests https://github.com/hannesa2/js2p-gradle/releases

```
git tag -a 1.2.2-alpha01 -m "Your text"
git tag -a 1.2.2-beta07 -m "Your text"
```

It has only one limitation: you need a new commit for a new release, that means one commit with two releases don't work

![image](https://user-images.githubusercontent.com/3314607/110620593-7a7e2980-8199-11eb-8fc8-bf3d2b96cec1.png)

