### PR TITLE
Temporary disable Generated annotation for Android, if tool java version is too high

### DIFF
--- a/demo/android/app/build.gradle
+++ b/demo/android/app/build.gradle
@@ -130,4 +130,6 @@ jsonSchema2Pojo {
 
     // Whether to initialize Set and List fields as empty collections, or leave them as null.
     boolean initializeCollections = true
+    // Include @Generated annotation
+    boolean includeGeneratedAnnotation = true
 }

--- a/demo/android/settings.gradle
+++ b/demo/android/settings.gradle
@@ -1,4 +1,4 @@
-rootProject.name = 'js2p-gradle sample'
+rootProject.name = 'js2d-gradle Android sample'
 
 include ':app'
 include ':lib'

--- a/src/main/groovy/com/github/eirnym/js2p/JsonSchemaPlugin.groovy
+++ b/src/main/groovy/com/github/eirnym/js2p/JsonSchemaPlugin.groovy
@@ -71,6 +71,11 @@ class JsonSchemaPlugin implements Plugin<Project> {
                 }
 
                 JsonSchemaExtension config = project.extensions.getByType(JsonSchemaExtension)
+
+                if (System.getProperty('java.specification.version').toFloat() >= 9) {
+                    config.includeGeneratedAnnotation = false  // Temporary fixes #71 and upstream issue #1212 (used Generated annotation is not compatible with AGP 7+)
+                }
+
                 ConfigurableFileCollection sourceFiles
 
                 if (config.source.isEmpty()) {


### PR DESCRIPTION
Generated annotation used by jsonschema2pojo is not compatible with packages used in Android and selected by AGP.