### PR TITLE
Automatic version name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ jobs:
         java: [ 8, 11, 15 ]
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v2


### PR DESCRIPTION
Move back to automatic version name and get rid of variable
* When you build with local non commited changes eg `3.1.0-23-g2d9c2f0-dirty`
* When you build without tag eg `3.1.0-23-g2d9c2f0`
* When you build with tag eg `3.2.0`