### PR TITLE
Update workflows for gradle wrapper

### DIFF
--- a/.github/workflows/gradle-wrapper-update.yml
+++ b/.github/workflows/gradle-wrapper-update.yml
@@ -2,8 +2,29 @@ name: Update Gradle Wrapper
 
 on:
   schedule:
-    - cron: "0 6 * * MON"
-
+    - cron: "0 2 * * *"
+  push:
+    branches:
+      - main
+    paths:
+      - 'gradle/**'
+      - 'gradlew'
+      - 'gradlew.bat'
+      - 'demo/*/*/gradle/**'
+      - 'demo/*/*/gradlew'
+      - 'demo/*/*/gradlew.bat'
+      - .github/workflows/gradle-wrapper-update.yml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'gradle/**'
+      - 'gradlew'
+      - 'gradlew.bat'
+      - 'demo/*/*/gradle/**'
+      - 'demo/*/*/gradlew'
+      - 'demo/*/*/gradlew.bat'
+      - .github/workflows/gradle-wrapper-update.yml
 jobs:
   updateWrapperPlugin:
     name: "Update Gradle Wrapper: Plugin"
@@ -13,79 +34,73 @@ jobs:
         with:
           fetch-depth: 0
       - name: Update Gradle Wrapper
-        uses: gradle-update/update-gradle-wrapper-action@v1.0.18
+        uses: gradle-update/update-gradle-wrapper-action@v1
         with:
+          path-exclude: demo/**
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           set-distribution-checksum: true
   updateWrapperJavaKotlinSample:
     name: "Update Gradle Wrapper: Java Kotlin DSL Sample"
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: demo/java/kotlin
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Update Gradle Wrapper
-        uses: gradle-update/update-gradle-wrapper-action@v1.0.18
+        uses: gradle-update/update-gradle-wrapper-action@v1
         with:
+          path: demo/java/kotlin
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          set-distribution-checksum: true
+  validationJavaModelPublishSample:
+    name: "Update Gradle Wrapper: Java Kotlin DSL Sample"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Update Gradle Wrapper
+        uses: gradle-update/update-gradle-wrapper-action@v1
+        with:
+          path: demo/java/model-publish
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           set-distribution-checksum: true
   updateWrapperJavaGroovySample:
     name: "Update Gradle Wrapper: Java Groovy DSL Sample"
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: demo/java/groovy
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Update Gradle Wrapper
-        uses: gradle-update/update-gradle-wrapper-action@v1.0.18
+        uses: gradle-update/update-gradle-wrapper-action@v1
         with:
+          path: demo/java/groovy
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           set-distribution-checksum: true
   updateWrapperAndroidAgp7Sample:
     name: "Update Gradle Wrapper: Android AGP 7 Sample"
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: demo/android/agp7
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Update Gradle Wrapper
-        uses: gradle-update/update-gradle-wrapper-action@v1.0.18
+        uses: gradle-update/update-gradle-wrapper-action@v1
         with:
+          path: demo/android/agp7
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          set-distribution-checksum: true
   updateWrapperAndroidAgp4Sample:
     name: "Update Gradle Wrapper: Android AGP 4 Sample"
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: demo/android/agp4
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Update Gradle Wrapper
-        uses: gradle-update/update-gradle-wrapper-action@v1.0.18
+        uses: gradle-update/update-gradle-wrapper-action@v1
         with:
+          path: demo/android/agp4
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-  updateWrapperAndroidAgp3Sample:
-    name: "Update Gradle Wrapper: Android AGP 3 Sample"
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: demo/android/agp3
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Update Gradle Wrapper
-        uses: gradle-update/update-gradle-wrapper-action@v1.0.18
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          set-distribution-checksum: true

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -11,14 +11,18 @@ on:
       - 'demo/*/*/gradle/**'
       - 'demo/*/*/gradlew'
       - 'demo/*/*/gradlew.bat'
-      - 'buildSrc/gradle*'
       - .github/workflows/gradle-wrapper-validation.yml
   pull_request:
     branches:
       - main
     paths:
       - 'gradle/**'
-      - 'gradlew*'
+      - 'gradlew'
+      - 'gradlew.bat'
+      - 'demo/*/*/gradle/**'
+      - 'demo/*/*/gradlew'
+      - 'demo/*/*/gradlew.bat'
+      - .github/workflows/gradle-wrapper-validation.yml
 env:
   GRADLE_OPTS: -Dorg.gradle.daemon=false -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process
 
@@ -30,7 +34,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: gradle/wrapper-validation-action@55e685c48d84285a5b0418cd094606e199cca3b6
+      - uses: gradle/wrapper-validation-action@v1
   validationJavaKotlinSample:
     name: "Wrapper validation: Java Kotlin DSL Sample"
     runs-on: ubuntu-latest
@@ -41,7 +45,18 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: gradle/wrapper-validation-action@55e685c48d84285a5b0418cd094606e199cca3b6
+      - uses: gradle/wrapper-validation-action@v1
+  validationJavaModelPublishSample:
+    name: "Wrapper validation: Java Kotlin DSL Sample"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: demo/java/model-publish
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: gradle/wrapper-validation-action@v1
   validationJavaGroovySample:
     name: "Wrapper validation: Java Groovy DSL Sample"
     runs-on: ubuntu-latest
@@ -52,7 +67,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: gradle/wrapper-validation-action@55e685c48d84285a5b0418cd094606e199cca3b6
+      - uses: gradle/wrapper-validation-action@v1
   validationAndroidAgp7Sample:
     name: "Wrapper validation: Android AGP 7 Sample"
     runs-on: ubuntu-latest
@@ -63,7 +78,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: gradle/wrapper-validation-action@55e685c48d84285a5b0418cd094606e199cca3b6
+      - uses: gradle/wrapper-validation-action@v1
   validationAndroidAgp4Sample:
     name: "Wrapper validation: Android AGP 4 Sample"
     runs-on: ubuntu-latest
@@ -74,15 +89,5 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: gradle/wrapper-validation-action@55e685c48d84285a5b0418cd094606e199cca3b6
-  validationAndroidAgp3Sample:
-    name: "Wrapper validation: Android AGP 3 Sample"
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: demo/android/agp3
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: gradle/wrapper-validation-action@55e685c48d84285a5b0418cd094606e199cca3b6
+      - uses: gradle/wrapper-validation-action@v1
+


### PR DESCRIPTION
* Workflows will check also on pull requests
* buildSrc is excluded
* Added model-publish demo
* Versions set to more generic
* AGP3 demo was removed
* Reviewed way, how gradle wrapper update checks the subfolders