### PR TITLE
More configuration option renames

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -54,7 +54,7 @@ Usage and migration documentation is located in separate documents.
 
 * xref:docs/usage/basic_{plugin_major}.adoc[Basic usage for {plugin_major}.x]
 * xref:docs/usage/parameters_{plugin_major}.adoc[Parameters for {plugin_major}.x]
-* xref:docs/migration/migration.adoc[Migration guide for {plugin_major}.x]
+* xref:docs/migration/migration_{plugin_major}.adoc[Migration guide for {plugin_major}.x]
 
 == Usage and migration information for all versions
 

--- a/docs/migration/migration_6.adoc
+++ b/docs/migration/migration_6.adoc
@@ -31,7 +31,7 @@ An execution configuration now contains following categories.
 | `klass`
 | General class generation options.
 // ------------------------------
-| `constructor`
+| `constructors`
 | Options define how given class can be instantiated.
 // ------------------------------
 | `methods`
@@ -79,7 +79,7 @@ An execution configuration now contains following categories.
 | refFragmentPathDelimiters
 | delimitersRefFragmentPath
 // ------------------------------
-.11+^.^| `klass`
+.12+^.^| `klass`
 | annotationStyle
 |
 // ------------------------------
@@ -104,6 +104,9 @@ An execution configuration now contains following categories.
 | inclusionLevel
 | jackson2InclusionLevel
 // ------------------------------
+| parcelable
+| androidParcelable
+// ------------------------------
 | serializable
 | annotateSerializable
 // ------------------------------
@@ -113,7 +116,7 @@ An execution configuration now contains following categories.
 | useTitleAsClassname
 | nameUseTitle
 // ------------------------------
-.5+^.^| `constructor`
+.4+^.^| `constructor`
 | includeAllPropertiesConstructor
 | allProperties
 // ------------------------------
@@ -121,15 +124,12 @@ An execution configuration now contains following categories.
 | annotateConstructorProperties
 // ------------------------------
 | includeCopyConstructor
-| copy
+| copyConstructor
 // ------------------------------
 | includeRequiredPropertiesConstructor
 | requiredProperties
 // ------------------------------
-| parcelable
-|
-// ------------------------------
-.16+^.^| `methods`
+.15+^.^| `methods`
 | generateBuilders
 | builders
 // ------------------------------

--- a/docs/usage/parameters_6.adoc
+++ b/docs/usage/parameters_6.adoc
@@ -158,6 +158,10 @@ a| The sort order to be applied when recursively processing the source files.
 |====
 | Name | Description | Notes
 // ------------------------------
+| androidParcelable
+| Whether to make the generated types `Parcelable`.
+| Used for Android development.
+// ------------------------------
 | annotateGenerated
 | Whether to mark generated classes with the `Generated` annotation.
 | It strongly depends on java version used to run POJO generator, not `targetVersion`.
@@ -233,6 +237,10 @@ This is used for types where a fully qualified name has not been supplied in the
 |====
 | Name | Type | Default
 // ------------------------------
+| androidParcelable
+| boolean
+| false
+// ------------------------------
 | annotateGenerated
 | boolean
 | false
@@ -296,13 +304,9 @@ This is used for types where a fully qualified name has not been supplied in the
   Used by some serialization libraries to get parameter names of constructors at runtime.
 | May not be available on Android
 // ------------------------------
-| copy
+| copyConstructor
 | Generate copy constructor to assign all properties from the originating class to the new class.
 |
-// ------------------------------
-| parcelable
-| Whether to make the generated types `Parcelable`.
-| Used for Android development.
 // ------------------------------
 | requiredProperties
 | This option determines whether the resulting object should include a constructor with only the required properties as parameters.
@@ -326,10 +330,6 @@ This is used for types where a fully qualified name has not been supplied in the
 | false
 // ------------------------------
 | copy
-| boolean
-| false
-// ------------------------------
-| parcelable
 | boolean
 | false
 // ------------------------------

--- a/src/main/kotlin/org/jsonschema2dataclass/js2p/Js2pConfig.kt
+++ b/src/main/kotlin/org/jsonschema2dataclass/js2p/Js2pConfig.kt
@@ -30,7 +30,7 @@ internal data class Js2pConfig(
                 targetDirectory.asFile.get(),
                 convert(config.io),
                 convert(config.klass),
-                convert(config.constructor),
+                convert(config.constructors),
                 convert(config.methods),
                 convert(config.fields),
                 convert(config.dateTime),
@@ -86,7 +86,7 @@ internal data class Js2pConfig(
     override fun isIncludeToString(): Boolean = methods.toStringMethod
     override fun isIncludeTypeInfo(): Boolean = klass.jackson2IncludeTypeInfo
     override fun isInitializeCollections(): Boolean = fields.initializeCollections
-    override fun isParcelable(): Boolean = constructor.parcelable
+    override fun isParcelable(): Boolean = klass.parcelable
     override fun isRemoveOldOutput(): Boolean = false
     override fun isSerializable(): Boolean = klass.annotateSerializable
     override fun isUseBigDecimals(): Boolean = fields.floatUseBigDecimal
@@ -116,6 +116,7 @@ internal data class Js2pConfigIO(
 )
 
 internal data class Js2pConfigClass(
+    val parcelable: Boolean,
     val annotateGenerated: Boolean,
     val annotateSerializable: Boolean,
     val annotationStyle: AnnotationStyle,
@@ -133,9 +134,8 @@ internal data class Js2pConfigConstructor(
     val allProperties: Boolean,
     val annotateConstructorProperties: Boolean,
     val copy: Boolean,
-    val parcelable: Boolean,
     val requiredProperties: Boolean,
-    val generate: Boolean = allProperties || annotateConstructorProperties || copy || parcelable || requiredProperties
+    val generate: Boolean = allProperties || annotateConstructorProperties || copy || requiredProperties
 )
 
 internal data class Js2pConfigMethod(
@@ -197,6 +197,7 @@ private fun convert(io: PluginConfigJs2pIO): Js2pConfigIO =
 
 private fun convert(klass: PluginConfigJs2pClass): Js2pConfigClass =
     Js2pConfigClass(
+        maybeDefault(klass.androidParcelable) { it.isParcelable },
         maybeDefault(klass.annotateGenerated) { it.isIncludeGeneratedAnnotation },
         maybeDefault(klass.annotateSerializable) { it.isSerializable },
         maybeDefaultEnum(klass.annotationStyle) { it.annotationStyle },
@@ -214,8 +215,7 @@ private fun convert(constructor: PluginConfigJs2pConstructor): Js2pConfigConstru
     Js2pConfigConstructor(
         maybeDefault(constructor.allProperties) { it.isIncludeAllPropertiesConstructor },
         maybeDefault(constructor.annotateConstructorProperties) { it.isIncludeConstructorPropertiesAnnotation },
-        maybeDefault(constructor.copy) { it.isIncludeCopyConstructor },
-        maybeDefault(constructor.parcelable) { it.isParcelable },
+        maybeDefault(constructor.copyConstructor) { it.isIncludeCopyConstructor },
         maybeDefault(constructor.requiredProperties) { it.isIncludeRequiredPropertiesConstructor },
     )
 

--- a/src/main/kotlin/org/jsonschema2dataclass/js2p/Js2pConfiguration.kt
+++ b/src/main/kotlin/org/jsonschema2dataclass/js2p/Js2pConfiguration.kt
@@ -56,6 +56,10 @@ abstract class PluginConfigJs2pIO {
 abstract class PluginConfigJs2pClass {
     @get:Input
     @get:Optional
+    abstract val androidParcelable: Property<Boolean>
+
+    @get:Input
+    @get:Optional
     abstract val annotateGenerated: Property<Boolean>
 
     @get:Input
@@ -110,11 +114,7 @@ abstract class PluginConfigJs2pConstructor {
 
     @get:Input
     @get:Optional
-    abstract val copy: Property<Boolean>
-
-    @get:Input
-    @get:Optional
-    abstract val parcelable: Property<Boolean>
+    abstract val copyConstructor: Property<Boolean>
 
     @get:Input
     @get:Optional
@@ -271,7 +271,7 @@ abstract class Js2pConfiguration @Inject constructor(
 
     @get:Nested
     @get:Optional
-    abstract val constructor: PluginConfigJs2pConstructor
+    abstract val constructors: PluginConfigJs2pConstructor
 
     @get:Nested
     @get:Optional


### PR DESCRIPTION
* constructors.parcelable -> klass.androidParcelable (it's more for a class, and it's Android specific)
* constructors.copy -> constructors.copyConstructor (readability)
* Fix README link
* Fix documentation formatting