### PR TITLE
build(deps): bump com.diffplug.spotless in /demo/java

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import com.diffplug.spotless.extra.wtp.EclipseWtpFormatterStep
 
 plugins {
     id("com.gradle.plugin-publish") version "1.1.0" apply false
-    id("com.diffplug.spotless") version "6.13.0"
+    id("com.diffplug.spotless") version "6.14.0"
 }
 
 allprojects {


### PR DESCRIPTION
Bumps com.diffplug.spotless from 6.13.0 to 6.14.0.

---
updated-dependencies:
- dependency-name: com.diffplug.spotless dependency-type: direct:production update-type: version-update:semver-minor ...

Signed-off-by: dependabot[bot] <support@github.com>